### PR TITLE
Backpressure error fix, and small ffixes on autocomplete and Console Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * GOTO definition for ClojureScript (as far as we can)
 * Auto-import
 * Clean unused imports
+* Problems when we stack multiple evaluations (see FIXME on repl-tooling)
+
+## 0.0.7
+* Fixes autocomplete error: https://github.com/mauricioszabo/atom-chlorine/issues/26
+* Fixes backpressure error: https://github.com/mauricioszabo/repl-tooling/issues/7
+* When we close the REPL console, we now disconnect from Socket REPLs
 
 ## 0.0.6
 * Fix https://github.com/mauricioszabo/atom-chlorine/issues/22

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/chlorine/providers_consumers/autocomplete.cljs
+++ b/src/chlorine/providers_consumers/autocomplete.cljs
@@ -34,7 +34,7 @@
                                         :type "function"
                                         :replacementPrefix prefix}))
                         clj->js)))
-      (.then @clj-completions clj->js))))
+      (some-> @clj-completions (.then clj->js)))))
 
 
 (def sug (atom suggestions))

--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -6,7 +6,8 @@
             [chlorine.ui.atom :as atom]
             [repl-tooling.repl-client :as repl-client]
             [repl-tooling.repl-client.clojure :as clj-repl]
-            [chlorine.aux :as aux]))
+            [chlorine.aux :as aux]
+            [repl-tooling.editor-integration.connection :as connection]))
 
 (defonce local-state
   (r/atom {:hostname "localhost"
@@ -80,6 +81,4 @@
     :else (already-connected)))
 
 (defn disconnect! []
-  (repl-client/disconnect! :clj-eval)
-  (repl-client/disconnect! :clj-aux)
-  (repl-client/disconnect! :cljs-eval))
+  (connection/disconnect!))

--- a/src/chlorine/ui/console.cljs
+++ b/src/chlorine/ui/console.cljs
@@ -4,8 +4,6 @@
 
 (def console-uri "atom://chlorine/console")
 
-; Just don't ask, Google Closure Compiler issues...
-
 (defn- from-console-id [^js ink]
   (-> ink .-Console
       (.fromId "chlorine")

--- a/src/chlorine/ui/inline_results.cljs
+++ b/src/chlorine/ui/inline_results.cljs
@@ -177,13 +177,14 @@
        [:div {:class "children"}
         (doall (map #(result-view result [:children %]) (keys-of)))])]))
 
-(defn view-for-result [eval-result]
-  (let [div (. js/document (createElement "div"))
-        res (r/atom [{:contents (editor-helpers/read-result eval-result)}])]
-    (r/render [:div
-               [:span "\033[0m"]
-               [result-view res [0]]] div)
-    [div res]))
+(defn view-for-result
+  ([eval-result] (view-for-result eval-result true))
+  ([eval-result parse?]
+   (let [div (. js/document (createElement "div"))
+         res (r/atom [{:contents (cond-> eval-result parse? editor-helpers/read-result)}])]
+     (r/render [:div
+                [result-view res [0]]] div)
+     [div res])))
 
 (defn render-result! [^js result eval-result]
   (let [[div res] (view-for-result eval-result)]


### PR DESCRIPTION
On this PR:

* Fixes autocomplete error: https://github.com/mauricioszabo/atom-chlorine/issues/26
* Fixes backpressure error: https://github.com/mauricioszabo/repl-tooling/issues/7
* When we close the REPL console, we now disconnect from Socket REPLs