### PR TITLE
Adds support for Cognitect's REBL

### DIFF
--- a/src/chlorine/core.cljs
+++ b/src/chlorine/core.cljs
@@ -43,6 +43,9 @@
   (aux/command-for "run-tests-in-ns" #(repl/run-tests-in-ns!))
   (aux/command-for "run-test-for-var" #(repl/run-test-at-cursor!))
 
+  (aux/command-for "inspect-block" #(repl/inspect-block!))
+  (aux/command-for "inspect-top-block" #(repl/inspect-top-block!))
+
   (aux/command-for "refresh-namespaces" refresh/run-refresh!)
   (aux/command-for "toggle-refresh-mode" refresh/toggle-refresh)
 

--- a/src/chlorine/repl.cljs
+++ b/src/chlorine/repl.cljs
@@ -182,6 +182,42 @@
                      (. editor getSelectedBufferRange)
                      (.getSelectedText editor))))
 
+(defn wrap-in-rebl-submit
+  "Clojure 1.10 only, require REBL on the classpath (and UI open)."
+  [code]
+  (str "(let [value " code "]"
+       " (try"
+       "  (when-let [d-val ((requiring-resolve 'clojure.datafy/datafy) value)]"
+       "   ((requiring-resolve 'cognitect.rebl/submit) '" code " d-val))"
+       "  (catch Throwable _))"
+       " value)"))
+
+(defn inspect-top-block!
+  ([] (inspect-top-block! (atom/current-editor)))
+  ([^js editor]
+   (let [range (. EditorUtils
+                 (getCursorInBlockRange editor #js {:topLevel true}))]
+     (some->> range
+              (.getTextInBufferRange editor)
+              (wrap-in-rebl-submit)
+              (eval-and-present editor
+                                (ns-for editor)
+                                (.getPath editor)
+                                range)))))
+
+(defn inspect-block!
+  ([] (inspect-block! (atom/current-editor)))
+  ([^js editor]
+   (let [range (. EditorUtils
+                 (getCursorInBlockRange editor))]
+     (some->> range
+              (.getTextInBufferRange editor)
+              (wrap-in-rebl-submit)
+              (eval-and-present editor
+                                (ns-for editor)
+                                (.getPath editor)
+                                range)))))
+
 (defn run-tests-in-ns!
   ([] (run-tests-in-ns! (atom/current-editor)))
   ([^js editor]
@@ -212,8 +248,8 @@
    (let [pos  (.getCursorBufferPosition editor)
          s    (atom/current-var editor)
          code (str "(do"
-                   "  (clojure.test/test-vars [#'" s "])"
-                   "  (println \"Tested\" '" s "))")]
+                   " (clojure.test/test-vars [#'" s "])"
+                   " (println \"Tested\" '" s "))")]
      (evaluate-aux editor
                    (ns-for editor)
                    (.getFileName editor)


### PR DESCRIPTION
Adds two commands: `inspect-block` and `inspect-top-block` that behave like `evaluate-block` and `evaluate-top-block` respectively, but also `submit` the code and value to REBL, if it is on the classpath.