### PR TITLE
Initial work on auto-installing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "create-react-class": "^15.6.3",
     "react": "^16.4.2",
-    "react-dom": "^16.4.2"
+    "react-dom": "^16.4.2",
+    "atom-package-deps": "^5.0.0"
   },
   "activationCommands": {
     "atom-workspace": [

--- a/src/chlorine/core.cljs
+++ b/src/chlorine/core.cljs
@@ -20,7 +20,12 @@
         (.. js/atom -workspace
             (observeTextEditors subscribe-editor-events))))
 
+(defn- install-dependencies-maybe []
+  (-> (.install (js/require "atom-package-deps") "chlorine")
+      (.then #(.log js/console "All dependencies installed."))))
+
 (defn activate [s]
+  (install-dependencies-maybe)
   (aux/reload-subscriptions!)
   (observe-editors)
   (console/register-console)


### PR DESCRIPTION
Here's a sketch demoing the feasibility of offering to install dependencies -- in this case the ink package.  It uses the atom-package-deps node module.

It's clumsy because it is triggered upon socket connection to a REPL (actually, the package's activation IIUC), so may be it (or something similar) can be made to offer a nicer experience.