### PR TITLE
Add tap-selection command

### DIFF
--- a/src/chlorine/core.cljs
+++ b/src/chlorine/core.cljs
@@ -52,6 +52,8 @@
   (aux/command-for "inspect-block" #(repl/inspect-block!))
   (aux/command-for "inspect-top-block" #(repl/inspect-top-block!))
 
+  (aux/command-for "tap-selection" #(repl/tap-selection!))
+
   (aux/command-for "refresh-namespaces" refresh/run-refresh!)
   (aux/command-for "toggle-refresh-mode" refresh/toggle-refresh)
 

--- a/src/chlorine/repl.cljs
+++ b/src/chlorine/repl.cljs
@@ -230,6 +230,25 @@
                                 (.getPath editor)
                                 range)))))
 
+(defn wrap-in-tap
+  "Clojure 1.10 only, as tap> is required"
+  [code]
+  (str "(let [value " code "]"
+       "  (try"
+       "     (tap> value)"
+       "  (catch Throwable _))"
+       "  value)"))
+
+(defn tap-selection!
+  ([] (tap-selection! (atom/current-editor)))
+  ([^js editor]
+   (some->> (.getSelectedText editor)
+            (wrap-in-tap)
+            (eval-and-present editor
+                              (ns-for editor)
+                              (.getPath editor)
+                              (. editor getSelectedBufferRange)))))
+
 (defn run-tests-in-ns!
   ([] (run-tests-in-ns! (atom/current-editor)))
   ([^js editor]


### PR DESCRIPTION
Here is an attempt at a command to take the current selection and apply tap> to it.

One use case is for integration with punk (https://github.com/Lokeh/punk) -- a REBL-like UI in a web browser.  There is a pull-request (https://github.com/Lokeh/punk/pull/12) at the punk repository for using punk with a JVM Clojure project and it may be possible to use one of the other existing adapters for a ClojureScript project.
