### PR TITLE
Select network text field content on focus

### DIFF
--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -20,13 +20,15 @@
     [:label "Host: "]
     [:input.input-text {:type "text"
                         :value (:hostname @local-state)
-                        :on-change #(swap! local-state assoc :hostname (-> % .-target .-value))}]]
+                        :on-change #(swap! local-state assoc :hostname (-> % .-target .-value))
+                        :on-focus #(-> % .-target .select)}]]
    [:div.block
     [:label "Port: "]
     [:input.input-text {:type "text"
                         :placeholder "port"
                         :value (:port @local-state)
-                        :on-change #(swap! local-state assoc :port (-> % .-target .-value int))}]]])
+                        :on-change #(swap! local-state assoc :port (-> % .-target .-value int))
+                        :on-focus #(-> % .-target .select)}]]])
 
 (defn destroy! [^js panel]
   (.destroy panel)


### PR DESCRIPTION
Currently, in the socket connection dialog, when a text field comes in to focus, the text is not selected (highlighted).  This commit is an attempt to have the text be selected on focus instead.