### PR TITLE
Fix REBL integration

### DIFF
--- a/src/chlorine/repl.cljs
+++ b/src/chlorine/repl.cljs
@@ -199,8 +199,7 @@
   [code]
   (str "(let [value " code "]"
        " (try"
-       "  (when-let [d-val ((requiring-resolve 'clojure.datafy/datafy) value)]"
-       "   ((requiring-resolve 'cognitect.rebl/submit) '" code " d-val))"
+       "  ((requiring-resolve 'cognitect.rebl/submit) '" code " value)"
        "  (catch Throwable _))"
        " value)"))
 


### PR DESCRIPTION
It turns out the `datafy` call is unnecessary and interferes with `Var` navigation in the latest version of REBL.