### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 * Problems when we stack multiple evaluations (see FIXME on repl-tooling)
 * Fix problems with unreadable forms
 
+## 0.1.1
+- Fix `#js` tagged literal
+- Shadow-CLJS can now evaluate multiple forms
+- Fix stacktraces on ClojureScript
+- Removed "shadow" on exception on CLJS (conflicts with light theme)
+- Fixed link spacing on renderer
+
 ## 0.1.0
 - New renderer for results
 - Fixed "leaking internal implementation" on some exceptions

--- a/styles/chlorine.less
+++ b/styles/chlorine.less
@@ -55,6 +55,7 @@ status-bar div.chlorine {
     font-weight: bold;
     font-size: 16px;
     margin-right: 10px;
+    width: 0px;
     height: 15px;
 
     &.closed::before {

--- a/styles/chlorine.less
+++ b/styles/chlorine.less
@@ -88,7 +88,6 @@ div.chlorine {
   div.exception {
     div.description {
       font-weight: bold;
-      text-shadow: 1px 1px 3px black;
     }
 
     div.additional {

--- a/styles/chlorine.less
+++ b/styles/chlorine.less
@@ -54,7 +54,7 @@ status-bar div.chlorine {
     font-family: 'Octicons Regular';
     font-weight: bold;
     font-size: 16px;
-    width: 15px;
+    margin-right: 10px;
     height: 15px;
 
     &.closed::before {


### PR DESCRIPTION
- Fix `#js` tagged literal
- Shadow-CLJS can now evaluate multiple forms
- Fix stacktraces on ClojureScript
- Removed "shadow" on exception on CLJS (conflicts with light theme)
- Fixed link spacing on renderer
