### PR TITLE
Take up less space in status bar

### DIFF
--- a/src/chlorine/providers_consumers/status_bar.cljs
+++ b/src/chlorine/providers_consumers/status_bar.cljs
@@ -11,14 +11,14 @@
      [:span
       " "
       [:img {:src (str "file://" js/__dirname "/clj.png") :width 18}]
-      (cond-> " CLJ connected"
-              (-> @state :config :refresh-mode (= :simple)) (str " (simple refresh)")
-              (-> @state :config :refresh-mode (not= :simple)) (str " (full refresh)"))])
+      (cond-> " CLJ"
+              (-> @state :config :refresh-mode (= :simple)) (str " (simple)")
+              (-> @state :config :refresh-mode (not= :simple)) (str " (full)"))])
 
    (when (-> @state :repls :cljs-eval)
      [:span {:style {:margin-left "13px"}}
       [:img {:src (str "file://" js/__dirname "/cljs.png") :width 18}]
-      " CLJS connected"])])
+      " CLJS"])])
 
 (defn activate [s]
   (swap! status-bar #(or % s))


### PR DESCRIPTION
The string `CLJ connected (simple refresh)` takes up a *lot* of real estate unnecessarily. `CLJ (simple)` is as informative but frees up a lot of space for other packages to use!