### PR TITLE
Release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Problems when we stack multiple evaluations (see FIXME on repl-tooling)
 * Fix problems with unreadable forms
 
+## 0.1.9
+- Fix goto var definition failing when the var was defined evaluating blocks, or with load-file
+
 ## 0.1.8
 - Fix GOTO definition
 - Takes up less space on status bar

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Fix goto var definition failing when the var was defined evaluating blocks, or with load-file
