### PR TITLE
enable tabbing in connection window

### DIFF
--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -20,12 +20,14 @@
    [:div.block
     [:label "Host: "]
     [:input.input-text {:type "text"
+                        :tabindex "1"
                         :value (:hostname @local-state)
                         :on-change #(swap! local-state assoc :hostname (-> % .-target .-value))
                         :on-focus #(-> % .-target .select)}]]
    [:div.block
     [:label "Port: "]
     [:input.input-text {:type "text"
+                        :tabindex "2"
                         :placeholder "port"
                         :value (:port @local-state)
                         :on-change #(swap! local-state assoc :port (-> % .-target .-value int))


### PR DESCRIPTION
This enables tabbing between fields in the "Connect to Socket REPL" window.