### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Auto-import
 * Clean unused imports
 
+### 0.2.1
+- Removed printing of `name.space=> ` on console for CLJS
+- Fixes styling issues on console tab
+- Fixed double-exception rendering on console tab
+
 ### 0.2.0
 - Connection to ClojureScript with Shadow-CLJS allows us to select the build ID
 - New autocomplete for Clojure without Compliment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Removed printing of `name.space=> ` on console for CLJS
- Fixes styling issues on console tab
- Fixed double-exception rendering on console tab
