### PR TITLE
Do not remove main.js during setup

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -R target/ .shadow-cljs/ lib/js/cljs-runtime/ lib/main.js
+rm -R target/ .shadow-cljs/ lib/js/cljs-runtime/
 
 npm install &&
 git submodule init &&


### PR DESCRIPTION
The setup script removes lib/main.js.  This change prevents that.