### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Auto-import
 * Clean unused imports
 
-### NEXT
+### 0.3.0
 - Fixed sending incomplete forms freezing Clojure REPL
 - When trying to connect to a wrong host/port, displays an error
 - Disable commands that other REPLs don't support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed sending incomplete forms freezing Clojure REPL
 - When trying to connect to a wrong host/port, displays an error
 - Disable commands that other REPLs don't support
+- Fixed edge case of internal implementation "leaking" over the Chlorine console and appearing on the output of evaluations
 
 #### Experimental support for new REPLs
 - Support for Babashka >= 0.0.24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -530,7 +530,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
# Release 0.3.0 (new REPLs!)
- Fixed sending incomplete forms freezing Clojure REPL
- When trying to connect to a wrong host/port, displays an error
- Disable commands that other REPLs don't support
- Fixed edge case of internal implementation "leaking" over the Chlorine console and appearing on the output of evaluations

## Experimental support for new REPLs
- Support for Babashka >= 0.0.24
- Support for ClojureCLR
- Support for Joker
- Support for more ClojureScript REPLs that open a socket REPL
