### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Clean unused imports
 
 
-### NEXT
+### 0.3.3
 - Fixed evaluation on CLR where it fails with "Unable to resolve symbol: str in this context"
 - Load-file working on multiple REPLs
 - Fixed UUIDs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Fixed evaluation on CLR where it fails with "Unable to resolve symbol: str in this context"
- Load-file working on multiple REPLs
- Fixed UUIDs
