### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Auto-import
 * Clean unused imports
 
-### NEXT
+### 0.3.4
 - Fixed connection on Arcadia
 - Some REPLs don't send a "disconnect" event when closing the socket, so we "simulate" a disconnect
 - Fixed "Disconnected from REPLs" appearing twice

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Some REPLs don't send a "disconnect" event when closing the socket, so we "simulate" a disconnect
- Fixed "Disconnected from REPLs" appearing twice
- Copy results to clipboard
