### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Auto-import
 * Clean unused imports
 
-### NEXT
+### 0.3.5
 - Fixed issues with "Copy to Clipboard"
 - Removed old connection methods like "Connect Clojure Socket REPL" and "Connect ClojureScript REPL"
 - Removed deprecated extension points

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Fixed issues with "Copy to Clipboard"
- Removed old connection methods like "Connect Clojure Socket REPL" and "Connect ClojureScript REPL"
- Removed deprecated extension points
