### PR TITLE
Release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Auto-import
 * Clean unused imports
 
+### 0.3.6
+- Added specs on doc-for-var (https://github.com/mauricioszabo/atom-chlorine/issues/100)
+- Fixed an issue with goto var definition where sometimes it wasn't able to find the var
+
 ### 0.3.5
 - Fixed issues with "Copy to Clipboard"
 - Removed old connection methods like "Connect Clojure Socket REPL" and "Connect ClojureScript REPL"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Added specs on doc-for-var (https://github.com/mauricioszabo/atom-chlorine/issues/100)
- Fixed an issue with goto var definition where sometimes it wasn't able to find the var
