### PR TITLE
Release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Auto-import
 * Clean unused imports
 
+### 0.3.8
+- Fixed error when trying to execute a ClojureScript code when REPL is not clj-connected
+- Fixed warnings when connecting to ClojureScript without reagent
+
 ### 0.3.7
 - Fixed "get current var" when cursor is at the end of the variable
 - Fixed warning messages connection to Shadow-CLJS when reagent is not present (https://github.com/mauricioszabo/atom-chlorine/issues/127)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Fixed error when trying to execute a ClojureScript code when REPL is not clj-connected
- Fixed warnings when connecting to ClojureScript without reagent
- First try to fix problem with autocomplete showing symbols on console tab (probably only on Windows)