### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - All "evaluate" commands are implemented without using Atom's APIs. They also are aware of reader symbols, so now `evaluate-block` over `'(+ 1 2 3)` will return a list, not run the function.
 - Added "interactive" evaluation
 - Goto var definition now works on ClojureScript
+- Babashka is now aware of namespaces
 
 ### 0.3.9
 - Fixed autocomplete error on dynamic vars (https://github.com/mauricioszabo/atom-chlorine/issues/132)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",


### PR DESCRIPTION
- Fixed test output not rendering on console
- Promoted all "experimental features" as they passed the battle test
- All "evaluate" commands are implemented without using Atom's APIs. They also are aware of reader symbols, so now `evaluate-block` over `'(+ 1 2 3)` will return a list, not run the function.
- Added "interactive" evaluation
- Goto var definition now works on ClojureScript
- Babashka is now aware of namespaces