### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Auto-import
 * Clean unused imports
 
-### NEXT
+### 0.4.3
 - Supporting Suitable for CLJS autocomplete
 - When evaluating top-level, considers the parens before the cursor if the selection is on the end of the line
 - Fixes for strange issues happening on evaluation of Clojure forms (sometimes, things were evaluating out-of-order or returning nil incorrectly)

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -R /tmp/node-v10.16.3-linux-x64
 
 ENV DISPLAY=:80
 ENV ELECTRON_ENABLE_LOGGING=true
-ENV JVM_OPTS='-Xmx1g'
+ENV JVM_OPTS='-Xmx3200m'
 
 RUN mkdir /root/.atom
 RUN echo "'*':\n  welcome:\n    showOnStartup: false\n  core:\n    telemetryConsent: \"no\"\n    disabledPackages: [\"github\"]\n  \"autocomplete-plus\":\n    enableAutoActivation: false" > /root/.atom/config.cson

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -2,8 +2,12 @@ FROM jamesnetherton/docker-atom-editor
 
 USER root
 
-RUN apt update
-RUN apt install -y xvfb ffmpeg openjdk-8-jdk netcat xz-utils
+RUN apt-get update
+RUN apt-get install -y wget gpg
+RUN wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+RUN apt-get install -y xvfb ffmpeg netcat xz-utils adoptopenjdk-11-openj9
 
 RUN cd /tmp && curl https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.xz | tar -xJ
 RUN cp -a /tmp/node-v10.16.3-linux-x64/* /usr
@@ -11,10 +15,11 @@ RUN rm -R /tmp/node-v10.16.3-linux-x64
 
 ENV DISPLAY=:80
 ENV ELECTRON_ENABLE_LOGGING=true
-ENV JVM_OPTS='-Xmx3200m'
 
 RUN mkdir /root/.atom
 RUN echo "'*':\n  welcome:\n    showOnStartup: false\n  core:\n    telemetryConsent: \"no\"\n    disabledPackages: [\"github\"]\n  \"autocomplete-plus\":\n    enableAutoActivation: false" > /root/.atom/config.cson
 
 WORKDIR /work
+
+
 CMD sh -c 'Xvfb -screen 0 1024x768x24+32 :80 & ./scripts/test'

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -11,6 +11,7 @@ RUN rm -R /tmp/node-v10.16.3-linux-x64
 
 ENV DISPLAY=:80
 ENV ELECTRON_ENABLE_LOGGING=true
+ENV JVM_OPTS='-Xmx1g'
 
 RUN mkdir /root/.atom
 RUN echo "'*':\n  welcome:\n    showOnStartup: false\n  core:\n    telemetryConsent: \"no\"\n    disabledPackages: [\"github\"]\n  \"autocomplete-plus\":\n    enableAutoActivation: false" > /root/.atom/config.cson

--- a/integration/chlorine-tests/shadow-cljs.edn
+++ b/integration/chlorine-tests/shadow-cljs.edn
@@ -3,7 +3,7 @@
 
  :dependencies [[org.clojure/core.async "0.4.474"]
                 [funcool/promesa "3.0.0"]
-                [check "0.1.0-SNAPSHOT"]]
+                [check "0.0.3-SNAPSHOT"]]
 
  :socket-repl {:port 3333}
  :builds {:tests {:target :node-library

--- a/integration/chlorine-tests/shadow-cljs.edn
+++ b/integration/chlorine-tests/shadow-cljs.edn
@@ -3,7 +3,7 @@
 
  :dependencies [[org.clojure/core.async "0.4.474"]
                 [funcool/promesa "3.0.0"]
-                [check "0.0.3-SNAPSHOT"]]
+                [check "0.1.0-SNAPSHOT"]]
 
  :socket-repl {:port 3333}
  :builds {:tests {:target :node-library

--- a/integration/chlorine-tests/test/chlorine/tests.cljs
+++ b/integration/chlorine-tests/test/chlorine/tests.cljs
@@ -2,6 +2,7 @@
   (:require [chlorine.utils :refer-macros [async async-testing]]
             [clojure.test :refer [is deftest run-all-tests run-tests] :as test]
             [check.core :refer-macros [check]]
+            [check.async :refer-macros [async-test]]
             [promesa.core :as p]
             ["remote" :as remote]))
 

--- a/integration/chlorine-tests/test/chlorine/tests.cljs
+++ b/integration/chlorine-tests/test/chlorine/tests.cljs
@@ -2,7 +2,6 @@
   (:require [chlorine.utils :refer-macros [async async-testing]]
             [clojure.test :refer [is deftest run-all-tests run-tests] :as test]
             [check.core :refer-macros [check]]
-            [check.async :refer-macros [async-test]]
             [promesa.core :as p]
             ["remote" :as remote]))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [],
   "repository": "https://github.com/mauricioszabo/atom-chlorine",

--- a/scripts/test
+++ b/scripts/test
@@ -4,7 +4,7 @@
 #cd integration/fixture-app && ./scripts/repl &
 for n in {1..35}; do
   ls integration/chlorine-tests/lib/main.js &>/dev/null && break
-  echo "Test plug-in not compiled yet, waiting..."
+  echo "Test plug-in not compiled yet, waiting... ($n)"
   sleep 15
 done
 

--- a/scripts/test
+++ b/scripts/test
@@ -11,7 +11,7 @@ done
 ls integration/chlorine-tests/lib/main.js &>/dev/null || exit 1
 sh -c 'sleep 240 && killall atom' &
 
-ffmpeg -video_size 1024x768 -f x11grab -i :80.0 /tmp/junit/out.mpg &
+nohup ffmpeg -video_size 1024x768 -f x11grab -i :80.0 /tmp/junit/out.mpg &
 
 atom --foreground /work/integration/chlorine-tests
 result=$?

--- a/scripts/test
+++ b/scripts/test
@@ -8,7 +8,7 @@ for n in {1..35}; do
   sleep 15
 done
 
-ls integration/chlorine-tests/lib/main.js &>/dev/null || docker logs test-server ; exit 1
+ls integration/chlorine-tests/lib/main.js &>/dev/null || (docker logs test-server && exit 1)
 sh -c 'sleep 240 && killall atom' &
 
 nohup ffmpeg -video_size 1024x768 -f x11grab -i :80.0 /tmp/junit/out.mpg &

--- a/scripts/test
+++ b/scripts/test
@@ -2,13 +2,13 @@
 
 #rm -Rf integration/fixture-app/target/
 #cd integration/fixture-app && ./scripts/repl &
-for n in {1..15}; do
+for n in {1..35}; do
   ls integration/chlorine-tests/lib/main.js &>/dev/null && break
   echo "Test plug-in not compiled yet, waiting..."
-  sleep 10
+  sleep 15
 done
 
-ls integration/chlorine-tests/lib/main.js &>/dev/null || exit 1
+ls integration/chlorine-tests/lib/main.js &>/dev/null || docker logs test-server ; exit 1
 sh -c 'sleep 240 && killall atom' &
 
 nohup ffmpeg -video_size 1024x768 -f x11grab -i :80.0 /tmp/junit/out.mpg &


### PR DESCRIPTION
- Supporting Suitable for CLJS autocomplete
- When evaluating top-level, considers the parens before the cursor if the selection is on the end of the line
- Fixes for strange issues happening on evaluation of Clojure forms (sometimes, things were evaluating out-of-order or returning nil incorrectly)
- Migrated autocomplete tools to use promises, to avoid crashing the Atom editor in case of failures while autocompleting
- Fixed a bug on Autocomplete (when disconnecting the REPL and adding/removing Compliment, the autocomplete would still try to use/not use Compliment after connecting to REPL)
