### PR TITLE
Release v0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Auto-import
 * Clean unused imports
 
+### 0.4.15
+- Fixed issue with GOTO Var Definition when the current file's full path is too long.
+
 ### 0.4.14
 - First try to fix opening an empty editor on MacOSX
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",

--- a/styles/chlorine.less
+++ b/styles/chlorine.less
@@ -24,7 +24,7 @@ div.chlorine.error {
   }
 
   a {
-    color: @text-color-error;
+    color: @text-color-error !important;
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
- Fixed issue with GOTO Var Definition when the current file's full path is too long.
