### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 * Auto-import
 * Clean unused imports
 
+### 0.5.2
+- Faster nREPL messages parsing
+- Load-file now prints the stacktrace when it fails to load
+- Fixed paths on Windows, so goto var definition and clicking on stacktraces will work
+
 ### 0.5.1
 - Simple fix for nREPL on slower sockets
 - (Possible) load-file fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Faster nREPL messages parsing
- Load-file now prints the stacktrace when it fails to load
- Fixed paths on Windows, so goto var definition and clicking on stacktraces will work
