### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Auto-import
 * Clean unused imports
 
+### 0.6.1
+- Fixed connection for other Clojure implementations like Clojerl, Joker, etc.
+
 ### 0.6.0
 - Interactive results (see [documentation](docs/extending.md))
 - First support for `info` command, if "Orchard" is on classpath

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Fixed connection for other Clojure implementations like Clojerl, Joker, etc.
