### PR TITLE
Readme: 'inline-results:clear-all' -> 'chlorine:clear-inline-results'

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This package does not register any keybindings to avoid keybinding conflict issu
   'shift-enter':  'chlorine:evaluate-block'
   'ctrl-enter':   'chlorine:evaluate-top-block'
   'ctrl-c':       'chlorine:break-evaluation'
-  'space space':  'inline-results:clear-all'
+  'space space':  'chlorine:clear-inline-results'
   'space x':      'chlorine:run-tests-in-ns'
   'space t':      'chlorine:run-test-for-var'
 


### PR DESCRIPTION
Update readme to reflect the change of 'inline-results:clear-all' into 'chlorine:clear-inline-results' in the keybindings example.