### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 * Auto-import
 * Clean unused imports
 
+## 0.8.0
+- Fix on regexp printing
+- Using another way to connect to Shadow-CLJS
+#### Experimental features on this version
+- Implemented the new Websocket REPL of Shadow-CLJS (Remote API)
+- For now, removed inspection of JS and resolving promises
+
 ## 0.7.5
 - Fixes on nREPL imports for Orchard, Compliment, etc (https://github.com/mauricioszabo/atom-chlorine/issues/191)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -203,6 +203,15 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
+    "bufferutil": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "dev": true,
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      }
+    },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
@@ -354,9 +363,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -611,6 +620,12 @@
         "is-stream": "^1.0.1"
       }
     },
+    "node-gyp-build": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+      "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w==",
+      "dev": true
+    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -681,9 +696,9 @@
       "dev": true
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -907,9 +922,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.9.10",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.9.10.tgz",
-      "integrity": "sha512-LfgqHJMpYQkQey33lqdX2QW7Y6tKJGb3ye4MlYtz5Z2mHvAYEsd9WttMUXchn26bItZ1gBuESshbirUJ5gaUIA==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.10.12.tgz",
+      "integrity": "sha512-LLBzhh7MOzVEIUkd3YOmiaDecXVBybfaHbfHYt5C+1x18gEhZhbi5APBeUWa7e7vmcB16nY6/R5XnKbt8OCelA==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.0.0",
@@ -1059,6 +1074,15 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "utf-8-validate": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "dev": true,
+      "requires": {
+        "node-gyp-build": "~3.7.0"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",
@@ -48,12 +48,14 @@
   },
   "devDependencies": {
     "ansi_up": "^4.0.4",
+    "bufferutil": "^4.0.1",
     "create-react-class": "^15.6.3",
     "grim": "^2.0.2",
     "react": "^16.3.0",
     "react-dom": "^16.13.0",
-    "shadow-cljs": "^2.9.10",
+    "shadow-cljs": "^2.10.12",
     "source-map-support": "^0.5.13",
+    "utf-8-validate": "^5.0.2",
     "ws": "^7.1.2"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -2,6 +2,7 @@
                 "repl-tooling/resources"]
 
  :dependencies [[check "0.1.0-SNAPSHOT" :exclusions [midje]]
+                [com.cognitect/transit-cljs "0.8.264"]
                 [funcool/promesa "4.0.2"]
                 [paprika "0.1.3-SNAPSHOT"]
                 [borkdude/sci "0.0.13-alpha.17"]

--- a/src/chlorine/ui/inline_results.cljs
+++ b/src/chlorine/ui/inline_results.cljs
@@ -36,15 +36,15 @@
            first)))
 
 (s/defn new-result [data :- schemas/EvalData]
-  (let [id (:id data)
-        range (:range data)
-        {:keys [editor]} (:editor-data data)
-        _ (when-let [old-marker (find-result editor range)]
-            (.destroy old-marker))
-        div (create-result id editor range)]
-    (doto div
-      (aset "classList" "chlorine result-overlay native-key-bindings")
-      (aset "innerHTML" "<div><span class='repl-tooling icon loading'></span></div>"))))
+  (when-let [editor (-> data :editor-data :editor)]
+    (let [id (:id data)
+          range (:range data)
+          _ (when-let [old-marker (find-result editor range)]
+              (.destroy old-marker))
+          div (create-result id editor range)]
+      (doto div
+        (aset "classList" "chlorine result-overlay native-key-bindings")
+        (aset "innerHTML" "<div><span class='repl-tooling icon loading'></span></div>")))))
 
 (s/defn update-result [result :- schemas/EvalResult]
   (let [id (:id result)


### PR DESCRIPTION
## 0.8.0
- Fix on regexp printing
- Using another way to connect to Shadow-CLJS
#### Experimental features on this version
- Implemented the new Websocket REPL of Shadow-CLJS (Remote API)
- For now, removed inspection of JS and resolving promises

-------

Will not publish this release so soon - if there are bugs, I'll probably not be able to fix then on a timely manner. If you want to try it, just clone this repository on your `~/.atom/packages` folder, rename `atom-chlorine` to just `chlorine`, and change to the branch `v0.8.0`.