### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Auto-import
 * Clean unused imports
 
+## 0.8.1
+- Possibility of running Shadow-CLJS Remote API commands (see: https://github.com/mauricioszabo/repl-tooling/pull/83)
+- Small fix on inline results, with Experimental Features, when saving a file with errors on Shadow-CLJS
+
 ## 0.8.0
 - Fix on regexp printing
 - Using another way to connect to Shadow-CLJS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",

--- a/src/chlorine/ui/inline_results.cljs
+++ b/src/chlorine/ui/inline_results.cljs
@@ -30,10 +30,10 @@
     div))
 
 (defn- find-result [^js editor range]
-  (-> editor
-      (.findMarkers #js {:endBufferRow (-> range last first)})
-      (->> (filter #(.-__divElement ^js %))
-           first)))
+  (some-> editor
+          (.findMarkers #js {:endBufferRow (-> range last first)})
+          (->> (filter #(.-__divElement ^js %))
+               first)))
 
 (s/defn new-result [data :- schemas/EvalData]
   (when-let [editor (-> data :editor-data :editor)]


### PR DESCRIPTION
- Possibility of running Shadow-CLJS Remote API commands (see: https://github.com/mauricioszabo/repl-tooling/pull/83)
- Small fix on inline results, with Experimental Features, when saving a file with errors on Shadow-CLJS
