### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Auto-import
 * Clean unused imports
 
+## 0.8.2
+- Support for resolving promises on Shadow Relay API
+- `tap>` support for Shadow-CLJS Relay API
+
 ## 0.8.1
 - Possibility of running Shadow-CLJS Remote API commands (see: https://github.com/mauricioszabo/repl-tooling/pull/83)
 - Small fix on inline results, with Experimental Features, when saving a file with errors on Shadow-CLJS

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Support for resolving promises on Shadow Relay API
- `tap>` support for Shadow-CLJS Relay API

![Peek 2020-07-18 23-57](https://user-images.githubusercontent.com/138037/87866020-855a2480-c952-11ea-8c16-b6b8f2f69df2.gif)
