### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Clickable stacktraces for Clojerl
 - Better printer for Clojerl and nREPL
 - Cutting some stdout messages from aux REPL
+- Better support for Lumo, CLR, and Joker
 
 ## 0.8.3
 - Fix error while trying to print lots of really small lines

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Clickable stacktraces for Clojerl
- Better printer for Clojerl and nREPL
- Cutting some stdout messages from aux REPL
- Better support for Lumo, CLR, and Joker
