### PR TITLE
Release v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## 0.9.3
 - Adding custom tag `:div/clj` to render Clojure forms
+- Fixed defining functions with same name as `clojure.core` (fixes https://github.com/mauricioszabo/atom-chlorine/issues/214).
+- Fixed clojure REPL not connecting on first try
 
 ## 0.9.2
 - Adding commands `render/add-class` and `render/set-attr`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 * Auto-import
 * Clean unused imports
 
-## 0.9.3
-- Adding custom tag `:div/clj` to render Clojure forms
+## 0.9.4
 - Fixed defining functions with same name as `clojure.core` (fixes https://github.com/mauricioszabo/atom-chlorine/issues/214).
 - Fixed clojure REPL not connecting on first try
+- Interactive eval redirects STDOUT
+
+## 0.9.3
+- Adding custom tag `:div/clj` to render Clojure forms
 
 ## 0.9.2
 - Adding commands `render/add-class` and `render/set-attr`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Fixed defining functions with same name as `clojure.core` (fixes https://github.com/mauricioszabo/atom-chlorine/issues/214).
- Fixed clojure REPL not connecting on first try
- Interactive eval redirects STDOUT
