### PR TITLE
Suggest port from .nrepl-port if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Auto-import
 * Clean unused imports
 
+## 0.10.3
+- Fixed issue detecting port from `.shadow-cljs/socket-repl.port` file on Windows
+- Added support for detecting port from `.nrepl-port` and `.socket-repl-port` files
+
 ## 0.10.2
 - Fixed issues with `prn` inside interactive renderer
 - Fixed issues with disconnect (sometimes it tries to run callbacks after disconnected)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",

--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -46,9 +46,14 @@
 (defn conn-view [cmd]
   (let [div (. js/document (createElement "div"))
         panel (.. js/atom -workspace (addModalPanel #js {:item div}))
-        port-file (-> js/atom .-project .getPaths first
-                      (str "/.shadow-cljs/socket-repl.port"))]
-    (when (existsSync port-file)
+        port-file (->> ["/.shadow-cljs/socket-repl.port"
+                        "/.nrepl-port"]
+                       (map (fn [path]
+                             (-> js/atom .-project .getPaths first
+                                 (str path))))
+                       (filter existsSync)
+                       first)]
+    (when port-file
       (swap! local-state assoc :port (-> port-file readFileSync .toString int)))
     (rdom/render [view] div)
     (aux/save-focus! div)

--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -47,6 +47,7 @@
   (let [div (. js/document (createElement "div"))
         panel (.. js/atom -workspace (addModalPanel #js {:item div}))
         port-file (->> ["/.shadow-cljs/socket-repl.port"
+                        "/.socket-repl-port"
                         "/.nrepl-port"]
                        (map (fn [path]
                              (-> js/atom .-project .getPaths first

--- a/src/chlorine/ui/connection.cljs
+++ b/src/chlorine/ui/connection.cljs
@@ -5,7 +5,8 @@
             [chlorine.state :refer [state]]
             [chlorine.ui.atom :as atom]
             [chlorine.utils :as aux]
-            ["fs" :refer [existsSync readFileSync]]))
+            ["fs" :as node.fs]
+            ["path" :as node.path]))
 
 (defonce local-state
   (r/atom {:hostname "localhost"
@@ -43,19 +44,23 @@
 (defn- as-clj [nodelist]
   (js->clj (.. js/Array -prototype -slice (call nodelist))))
 
+(defn- set-port-from-file! []
+  (let [port-file (->> [[".shadow-cljs" "socket-repl.port"]
+                        [".socket-repl-port"]
+                        [".nrepl-port"]]
+                       (map (fn [path]
+                             (apply node.path/join
+                                    (-> js/atom .-project .getPaths first)
+                                    path)))
+                       (filter node.fs/existsSync)
+                       first)]
+   (when port-file
+    (swap! local-state assoc :port (-> port-file node.fs/readFileSync .toString int)))))
+
 (defn conn-view [cmd]
   (let [div (. js/document (createElement "div"))
-        panel (.. js/atom -workspace (addModalPanel #js {:item div}))
-        port-file (->> ["/.shadow-cljs/socket-repl.port"
-                        "/.socket-repl-port"
-                        "/.nrepl-port"]
-                       (map (fn [path]
-                             (-> js/atom .-project .getPaths first
-                                 (str path))))
-                       (filter existsSync)
-                       first)]
-    (when port-file
-      (swap! local-state assoc :port (-> port-file readFileSync .toString int)))
+        panel (.. js/atom -workspace (addModalPanel #js {:item div}))]
+    (set-port-from-file!)
     (rdom/render [view] div)
     (aux/save-focus! div)
     (doseq [elem (-> div (.querySelectorAll "input") as-clj)]


### PR DESCRIPTION
Currently, chlorine pre-fills the connection port if it can find `/.shadow-cljs/socket-repl.port`.

I've added additional support for `.nrepl-port` if it exists (as generated by `lein repl`) and `.socket-repl-port`.

Let me know if you'd like it refactored (say, moving all the port-file logic into a separate fn).