### PR TITLE
Release v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## 0.10.3
 - Fixed issue detecting port from `.shadow-cljs/socket-repl.port` file on Windows
 - Added support for detecting port from `.nrepl-port` and `.socket-repl-port` files
+- Trying to fix issue https://github.com/mauricioszabo/atom-chlorine/issues/234
 
 ## 0.10.2
 - Fixed issues with `prn` inside interactive renderer


### PR DESCRIPTION
- Fixed issue detecting port from `.shadow-cljs/socket-repl.port` file on Windows
- Added support for detecting port from `.nrepl-port` and `.socket-repl-port` files
- Trying to fix issue https://github.com/mauricioszabo/atom-chlorine/issues/234
