### PR TITLE
Release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ## Next
 
+## 0.12.0
+- Migrated most of Pathom code to a new project called Duck-REPLed
+- Disabled clj-kondo statistics for now
+- Fixed stacktraces in Clojerl
+- Fixed Lumo REPL
+
 ## 0.11.2
 - Making connect_socket callable from init.js/init.coffee
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Disabled clj-kondo statistics for now
 - Fixed stacktraces in Clojerl
 - Fixed Lumo REPL
+- Source for var now works for ClojureScript with Shadow-CLJS
 
 ## 0.11.2
 - Making connect_socket callable from init.js/init.coffee

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chlorine",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chlorine",
   "main": "./lib/main",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Socket REPL client for Clojure and ClojureScript",
   "keywords": [
     "clojure",


### PR DESCRIPTION
- Migrated most of Pathom code to a new project called Duck-REPLed
- Disabled clj-kondo statistics for now
- Fixed stacktraces in Clojerl
- Fixed Lumo REPL
- Source for var now works for ClojureScript with Shadow-CLJS